### PR TITLE
feat(images): introduce layout-aware image delivery profiles

### DIFF
--- a/shared-types/config/image-delivery/app-context.image-delivery.types.ts
+++ b/shared-types/config/image-delivery/app-context.image-delivery.types.ts
@@ -1,0 +1,10 @@
+// shared-types/config/image-delivery/app-context.image-delivery.types.ts
+
+import type {
+  AppStateImageDeliveryConfig,
+  AppStateImageDeliveryProfile,
+} from "@shared-types/config/image-delivery/app-state.image-delivery.types";
+
+export type AppContextImageDeliveryConfig = AppStateImageDeliveryConfig;
+
+export type AppContextImageDeliveryProfile = AppStateImageDeliveryProfile;

--- a/shared-types/config/image-delivery/app-render-context.image-delivery.types.ts
+++ b/shared-types/config/image-delivery/app-render-context.image-delivery.types.ts
@@ -1,0 +1,5 @@
+// shared-types/config/image-delivery/app-render-context.image-delivery.types.ts
+
+import type { AppContextImageDeliveryConfig } from "@shared-types/config/image-delivery/app-context.image-delivery.types";
+
+export type AppRenderContextImageDeliveryConfig = AppContextImageDeliveryConfig;

--- a/shared-types/config/image-delivery/app-state.image-delivery.types.ts
+++ b/shared-types/config/image-delivery/app-state.image-delivery.types.ts
@@ -1,0 +1,10 @@
+// shared-types/config/image-delivery/app-state.image-delivery.types.ts
+
+import type {
+  AuthoredImageDeliveryConfig,
+  AuthoredImageDeliveryProfile,
+} from "@shared-types/config/image-delivery/authored.image-delivery.types";
+
+export type AppStateImageDeliveryConfig = AuthoredImageDeliveryConfig;
+
+export type AppStateImageDeliveryProfile = AuthoredImageDeliveryProfile;

--- a/shared-types/config/image-delivery/authored.image-delivery.types.ts
+++ b/shared-types/config/image-delivery/authored.image-delivery.types.ts
@@ -1,0 +1,12 @@
+// shared-types/config/image-delivery/authored.image-delivery.types.ts
+
+import type { ImageDeliveryProfileId } from "@shared-types/config/image-delivery/id.image-delivery.types";
+
+export type AuthoredImageDeliveryProfile = Readonly<{
+  sizes: string;
+  widths: readonly number[];
+}>;
+
+export type AuthoredImageDeliveryConfig = Readonly<{
+  [K in ImageDeliveryProfileId]: AuthoredImageDeliveryProfile;
+}>;

--- a/shared-types/config/image-delivery/id.image-delivery.types.ts
+++ b/shared-types/config/image-delivery/id.image-delivery.types.ts
@@ -1,0 +1,11 @@
+// shared-types/config/image-delivery/id.image-delivery.types.ts
+
+export type ImageDeliveryProfileId =
+  | "fullBleed"
+  | "contentWidth"
+  | "homepageHero"
+  | "homepageJournalFeature"
+  | "homepageImageStrip"
+  | "listingThumbnail"
+  | "articleHero"
+  | "articleInline";

--- a/shared-types/media/photo/app-render-context.render-photo.types.ts
+++ b/shared-types/media/photo/app-render-context.render-photo.types.ts
@@ -1,6 +1,51 @@
-import type { AppRenderContextPhoto } from "@shared-types/media/photo/app-render-context.photo.types";
+// shared-types/media/photo/app-render-context.render-photo.types.ts
 
-export type AppRenderContextRenderImage = Pick<
-  AppRenderContextPhoto,
-  "src" | "srcset" | "sizes" | "alt" | "width" | "height" | "ratio"
+import type { MetadataLabelId } from "@shared-types/config/metadata-labels/id.metadata-labels.types";
+import type { AppContextPhotoMetadata } from "@shared-types/media/photo/app-context.photo.types";
+import type { AppRenderContextRenderImage } from "@shared-types/media/render-image/app-render-context.render-image.types";
+import type { ReplaceAndOmit } from "@shared-types/shared-types-utils/replace.shared.types";
+
+type OmittedFields =
+  | "sourceFileName"
+  | "cloudflareImageId"
+  | "cloudflareUploadedAt"
+  | "cameraMake"
+  | "cameraModel"
+  | "lensModel"
+  | "exposureTime"
+  | "aperture"
+  | "iso"
+  | "focalLength"
+  | "focalLength35mm"
+  | "latitude"
+  | "longitude"
+  | "resolvedLocation"
+  | "photographer"
+  | "copyright"
+  | "readableLocation"
+  | "capturedAt";
+
+type ReplacementFields = AppRenderContextRenderImage &
+  Readonly<{
+    attribution: string | null;
+    meta: readonly AppRenderContextPhotoMetaGroup[];
+  }>;
+
+export type AppRenderContextPhotoMetaItem = Readonly<{
+  id: MetadataLabelId;
+  label: string;
+  description: string | null;
+  value: string;
+  datetime?: string;
+}>;
+
+export type AppRenderContextPhotoMetaGroup = Readonly<{
+  kind: "context" | "settings";
+  items: readonly AppRenderContextPhotoMetaItem[];
+}>;
+
+export type AppRenderContextPhoto = ReplaceAndOmit<
+  AppContextPhotoMetadata,
+  ReplacementFields,
+  OmittedFields
 >;

--- a/shared-types/media/render-image/app-context.render-image.types.ts
+++ b/shared-types/media/render-image/app-context.render-image.types.ts
@@ -1,0 +1,9 @@
+// shared-types/media/render-image/app-context.render-image.types.ts
+
+import type { AppContextImageDeliveryProfile } from "@shared-types/config/image-delivery/app-context.image-delivery.types";
+import type { AppContextPhotoMetadata } from "@shared-types/media/photo/app-context.photo.types";
+
+export type AppContextResolvedPhoto = Readonly<{
+  metadata: AppContextPhotoMetadata;
+  delivery: AppContextImageDeliveryProfile;
+}>;

--- a/shared-types/media/render-image/app-render-context.render-image.types.ts
+++ b/shared-types/media/render-image/app-render-context.render-image.types.ts
@@ -1,0 +1,14 @@
+// shared-types/media/render-image/app-render-context.render-image.types.ts
+
+export type AppRenderContextRenderImage = Readonly<{
+  src: string;
+  srcset: readonly string[];
+  sizes: string;
+  alt: string;
+  width: number;
+  height: number;
+  ratio: Readonly<{
+    width: number;
+    height: number;
+  }>;
+}>;

--- a/shared-types/media/render-image/authored.render-image.types.ts
+++ b/shared-types/media/render-image/authored.render-image.types.ts
@@ -1,0 +1,9 @@
+// shared-types/media/render-image/authored.render-image.types.ts
+
+import type { PhotoId } from "@shared-types/media/photo/id.photo.types";
+
+export type AuthoredPhotoReference = Readonly<{
+  id: PhotoId;
+  sizes?: string;
+  widths?: readonly number[];
+}>;

--- a/shared-types/page-content/block/hero/app-context.hero.block.types.ts
+++ b/shared-types/page-content/block/hero/app-context.hero.block.types.ts
@@ -1,12 +1,12 @@
 // shared-types/page-content/block/hero/app-context.hero.block.types.ts
 
 import type { AppStateHeroBlock } from "@shared-types/page-content/block/hero/app-state.hero.block.types";
-import type { AppContextPhotoMetadata } from "@shared-types/media/photo/app-context.photo.types";
+import type { AppContextResolvedPhoto } from "@shared-types/media/render-image/app-context.render-image.types";
 
 import type { ReplaceAndOmit } from "@shared-types/shared-types-utils/replace.shared.types";
 
 type ResolvedFields = Readonly<{
-  photo: AppContextPhotoMetadata;
+  photo: AppContextResolvedPhoto;
 }>;
 
 export type AppContextHeroBlock = ReplaceAndOmit<

--- a/shared-types/page-content/block/homepage-hero/app-context.homepage-hero.block.types.ts
+++ b/shared-types/page-content/block/homepage-hero/app-context.homepage-hero.block.types.ts
@@ -3,13 +3,13 @@
 import type { AppStateHomepageHeroBlock } from "@shared-types/page-content/block/homepage-hero/app-state.homepage-hero.block.types";
 import type { AppContextInline } from "@shared-types/page-content/inline/app-context.inline-content.types";
 import type { AppContextInternalLink } from "@shared-types/links/app-context.links.types";
-import type { AppContextPhotoMetadata } from "@shared-types/media/photo/app-context.photo.types";
+import type { AppContextResolvedPhoto } from "@shared-types/media/render-image/app-context.render-image.types";
 import type { ReplaceAndOmit } from "@shared-types/shared-types-utils/replace.shared.types";
 
 type ResolvedFields = Readonly<{
   intro: AppContextInline[];
   primaryLink: AppContextInternalLink | null;
-  photo: AppContextPhotoMetadata;
+  photo: AppContextResolvedPhoto;
 }>;
 
 export type AppContextHomepageHeroBlock = ReplaceAndOmit<

--- a/shared-types/page-content/block/homepage-journal-listing/app-render-context.homepage-journal-listing.block.types.ts
+++ b/shared-types/page-content/block/homepage-journal-listing/app-render-context.homepage-journal-listing.block.types.ts
@@ -1,8 +1,7 @@
 // shared-types/page-content/block/homepage-journal-listing/app-render-context.homepage-journal-listing.block.types.ts
 
 import type { AppContextHomepageJournalListingBlock } from "@shared-types/page-content/block/homepage-journal-listing/app-context.homepage-journal-listing.block.types";
-import type { AppRenderContextRenderImage } from "@shared-types/media/photo/app-render-context.render-photo.types";
-
+import type { AppRenderContextRenderImage } from "@shared-types/media/render-image/app-render-context.render-image.types";
 import type { Replace } from "@shared-types/shared-types-utils/replace.shared.types";
 
 export type AppRenderContextHomepageJournalListingItem = Readonly<{

--- a/shared-types/page-content/block/image-strip/app-context.image-strip.block.types.ts
+++ b/shared-types/page-content/block/image-strip/app-context.image-strip.block.types.ts
@@ -1,14 +1,15 @@
 // shared-types/page-content/block/image-strip/app-context.image-strip.block.types.ts
 
 import type { AppStateImageStripBlock } from "@shared-types/page-content/block/image-strip/app-state.image-strip.block.types";
-import type { AppContextPhotoMetadata } from "@shared-types/media/photo/app-context.photo.types";
+import type { AppContextResolvedPhoto } from "@shared-types/media/render-image/app-context.render-image.types";
+
 import type { Replace } from "@shared-types/shared-types-utils/replace.shared.types";
 
-type ResolvedFields = Readonly<{
-  photos: readonly AppContextPhotoMetadata[];
+type RuntimeFields = Readonly<{
+  photos: readonly AppContextResolvedPhoto[];
 }>;
 
 export type AppContextImageStripBlock = Replace<
   AppStateImageStripBlock,
-  ResolvedFields
+  RuntimeFields
 >;

--- a/shared-types/page-content/block/image-strip/app-render-context.image-strip.block.types.ts
+++ b/shared-types/page-content/block/image-strip/app-render-context.image-strip.block.types.ts
@@ -1,13 +1,11 @@
 // shared-types/page-content/block/image-strip/app-render-context.image-strip.block.types.ts
 
 import type { AppContextImageStripBlock } from "@shared-types/page-content/block/image-strip/app-context.image-strip.block.types";
-import type { AppRenderContextPhoto } from "@shared-types/media/photo/app-render-context.photo.types";
+import type { AppRenderContextRenderImage } from "@shared-types/media/render-image/app-render-context.render-image.types";
+
 import type { Replace } from "@shared-types/shared-types-utils/replace.shared.types";
 
-export type AppRenderContextImageStripPhoto = Pick<
-  AppRenderContextPhoto,
-  "src" | "srcset" | "sizes" | "alt" | "width" | "height" | "ratio"
->;
+export type AppRenderContextImageStripPhoto = AppRenderContextRenderImage;
 
 type ResolvedFields = Readonly<{
   photos: readonly AppRenderContextImageStripPhoto[];

--- a/shared-types/page-content/block/journal-listing/app-context.journal-listing.block.types.ts
+++ b/shared-types/page-content/block/journal-listing/app-context.journal-listing.block.types.ts
@@ -2,7 +2,7 @@
 
 import type { AppStateJournalListingBlock } from "@shared-types/page-content/block/journal-listing/app-state.journal-listing.block.types";
 import type { AppContextPagination } from "@shared-types/page-content/shared/pagination/app-context.pagination.shared.types";
-import type { AppContextPhotoMetadata } from "@shared-types/media/photo/app-context.photo.types";
+import type { AppContextResolvedPhoto } from "@shared-types/media/render-image/app-context.render-image.types";
 
 import type { Replace } from "@shared-types/shared-types-utils/replace.shared.types";
 
@@ -13,7 +13,7 @@ export type AppContextJournalListingItem = Readonly<{
   intro: string | null;
   eyebrow: string | null;
   publishedAt: string | null;
-  image: AppContextPhotoMetadata | null;
+  image: AppContextResolvedPhoto | null;
 }>;
 
 type RuntimeFields = Readonly<{

--- a/shared-types/page-content/block/journal-listing/app-render-context.journal-listing.block.types.ts
+++ b/shared-types/page-content/block/journal-listing/app-render-context.journal-listing.block.types.ts
@@ -1,10 +1,10 @@
 // shared-types/page-content/block/journal-listing/app-render-context.journal-listing.block.types.ts
 
 import type { AppContextJournalListingBlock } from "@shared-types/page-content/block/journal-listing/app-context.journal-listing.block.types";
+import type { AppRenderContextRenderImage } from "@shared-types/media/render-image/app-render-context.render-image.types";
 import type { AppRenderContextPagination } from "@shared-types/page-content/shared/pagination/app-render-context.pagination.shared.types";
 
 import type { Replace } from "@shared-types/shared-types-utils/replace.shared.types";
-import type { AppRenderContextPhoto } from "@shared-types/media/photo/app-render-context.photo.types";
 
 export type AppRenderContextJournalListingItem = Readonly<{
   id: string;
@@ -14,7 +14,7 @@ export type AppRenderContextJournalListingItem = Readonly<{
   eyebrow: string | null;
   publishedAt: string | null;
   publishedLabel: string | null;
-  image: AppRenderContextPhoto | null;
+  image: AppRenderContextRenderImage | null;
 }>;
 
 type RuntimeFields = Readonly<{

--- a/src/app-context/create.app-context.ts
+++ b/src/app-context/create.app-context.ts
@@ -98,6 +98,7 @@ export const appContextCreate = async (
     publicPages: appState.getPublicPages,
     currentPageSlug: pageState.slug,
     routingPagination: routing.kind === "found" ? routing.pagination : null,
+    imageDelivery: appState.imageDelivery,
   });
 
   return new AppContext({

--- a/src/app-context/resolve/page-content/block/hero/hero.resolve.app-context.test.ts
+++ b/src/app-context/resolve/page-content/block/hero/hero.resolve.app-context.test.ts
@@ -6,8 +6,19 @@ import type { PhotoId } from "@shared-types/media/photo/id.photo.types";
 
 import { appContextResolveHeroBlock } from "@app-context/resolve/page-content/block/hero/hero.resolve.app-context";
 
+const imageDelivery = {
+  fullBleed: {
+    sizes: "100vw",
+    widths: [960, 1280, 1600, 1920],
+  },
+  contentWidth: {
+    sizes: "(min-width: 1200px) 960px, calc(100vw - 2rem)",
+    widths: [640, 960, 1280, 1600],
+  },
+} as const;
+
 describe("appContextResolveHeroBlock", () => {
-  it("resolves the hero photo from context photos", () => {
+  it("resolves the immersive hero photo with full bleed delivery", () => {
     const block: AppStateHeroBlock = {
       kind: "hero",
       flow: "breakout",
@@ -21,6 +32,7 @@ describe("appContextResolveHeroBlock", () => {
     };
 
     const context = {
+      imageDelivery,
       resolvePhoto: jest.fn((photoId: PhotoId) => {
         if (photoId === ("coot" as PhotoId)) return photo;
 
@@ -32,10 +44,47 @@ describe("appContextResolveHeroBlock", () => {
 
     expect(result).toEqual({
       kind: "hero",
-      photoId: "coot",
       immersive: true,
       flow: "breakout",
-      photo,
+      photo: {
+        metadata: photo,
+        delivery: imageDelivery.fullBleed,
+      },
+    });
+  });
+
+  it("resolves the non-immersive hero photo with content-width delivery", () => {
+    const block: AppStateHeroBlock = {
+      kind: "hero",
+      flow: "content",
+      immersive: false,
+      photoId: "coot" as PhotoId,
+    };
+
+    const photo = {
+      id: "coot",
+      title: "Coot",
+    };
+
+    const context = {
+      imageDelivery,
+      resolvePhoto: jest.fn((photoId: PhotoId) => {
+        if (photoId === ("coot" as PhotoId)) return photo;
+
+        return null;
+      }),
+    } as unknown as AppContextPageContentResolverContext;
+
+    const result = appContextResolveHeroBlock(block, context);
+
+    expect(result).toEqual({
+      kind: "hero",
+      immersive: false,
+      flow: "content",
+      photo: {
+        metadata: photo,
+        delivery: imageDelivery.contentWidth,
+      },
     });
   });
 
@@ -48,12 +97,14 @@ describe("appContextResolveHeroBlock", () => {
     };
 
     const context = {
+      imageDelivery,
       resolvePhoto: jest.fn(() => null),
     } as unknown as AppContextPageContentResolverContext;
 
     expect(() => appContextResolveHeroBlock(block, context)).toThrow(
       "No AppContext photo resolved for hero photoId: missing-photo",
     );
+
     expect(context.resolvePhoto).toHaveBeenCalledWith("missing-photo");
   });
 });

--- a/src/app-context/resolve/page-content/block/hero/hero.resolve.app-context.ts
+++ b/src/app-context/resolve/page-content/block/hero/hero.resolve.app-context.ts
@@ -18,7 +18,14 @@ export const appContextResolveHeroBlock = (
   }
 
   return {
-    ...module,
-    photo,
+    kind: module.kind,
+    immersive: module.immersive,
+    flow: module.flow,
+    photo: {
+      metadata: photo,
+      delivery: module.immersive
+        ? context.imageDelivery.fullBleed
+        : context.imageDelivery.contentWidth,
+    },
   };
 };

--- a/src/app-context/resolve/page-content/block/homepage-hero/homepage-hero.resolve.app-context.test.ts
+++ b/src/app-context/resolve/page-content/block/homepage-hero/homepage-hero.resolve.app-context.test.ts
@@ -15,6 +15,13 @@ jest.mock(
   }),
 );
 
+const imageDelivery = {
+  homepageHero: {
+    sizes: "(min-width: 1200px) 640px, calc(100vw - 2rem)",
+    widths: [640, 960, 1280],
+  },
+} as const;
+
 describe("appContextResolveHomepageHero", () => {
   const mockedAppContextResolveInline = jest.mocked(appContextResolveInline);
 
@@ -51,6 +58,7 @@ describe("appContextResolveHomepageHero", () => {
 
     const context = {
       photos: [photo],
+      imageDelivery,
       resolveInternalLink: jest.fn().mockReturnValue(resolvedPrimaryLink),
     } as unknown as AppContextPageContentResolverContext;
 
@@ -87,7 +95,10 @@ describe("appContextResolveHomepageHero", () => {
           value: "Hello",
         },
       ],
-      photo,
+      photo: {
+        metadata: photo,
+        delivery: imageDelivery.homepageHero,
+      },
       primaryLink: resolvedPrimaryLink,
     });
 
@@ -109,6 +120,7 @@ describe("appContextResolveHomepageHero", () => {
 
     const context = {
       photos: [photo],
+      imageDelivery,
       resolveInternalLink: jest.fn(),
     } as unknown as AppContextPageContentResolverContext;
 
@@ -130,7 +142,10 @@ describe("appContextResolveHomepageHero", () => {
       eyebrow: null,
       title: "Field notes from the edge",
       intro: [],
-      photo,
+      photo: {
+        metadata: photo,
+        delivery: imageDelivery.homepageHero,
+      },
       primaryLink: null,
     });
 
@@ -141,6 +156,7 @@ describe("appContextResolveHomepageHero", () => {
   it("throws when the homepage hero photo is not resolved in context", () => {
     const context = {
       photos: [],
+      imageDelivery,
       resolveInternalLink: jest.fn(),
     } as unknown as AppContextPageContentResolverContext;
 

--- a/src/app-context/resolve/page-content/block/homepage-hero/homepage-hero.resolve.app-context.ts
+++ b/src/app-context/resolve/page-content/block/homepage-hero/homepage-hero.resolve.app-context.ts
@@ -29,7 +29,10 @@ export const appContextResolveHomepageHero = (
     intro: module.intro.map((content) =>
       appContextResolveInline(content, context),
     ),
-    photo,
+    photo: {
+      metadata: photo,
+      delivery: context.imageDelivery.homepageHero,
+    },
     primaryLink: module.primaryLink
       ? context.resolveInternalLink(module.primaryLink)
       : null,

--- a/src/app-context/resolve/page-content/block/homepage-journal-listing/homepage-journal-listing.resolve.app-context.test.ts
+++ b/src/app-context/resolve/page-content/block/homepage-journal-listing/homepage-journal-listing.resolve.app-context.test.ts
@@ -14,6 +14,13 @@ jest.mock(
   }),
 );
 
+const imageDelivery = {
+  homepageJournalFeature: {
+    sizes: "(min-width: 1200px) 740px, calc(100vw - 2rem)",
+    widths: [640, 960, 1280],
+  },
+} as const;
+
 describe("appContextResolveHomepageJournalListingBlock", () => {
   const mockedAppContextResolveJournalListingItems = jest.mocked(
     appContextResolveJournalListingItems,
@@ -24,7 +31,9 @@ describe("appContextResolveHomepageJournalListingBlock", () => {
   });
 
   it("limits entries to the configured item count", () => {
-    const context = {} as AppContextPageContentResolverContext;
+    const context = {
+      imageDelivery,
+    } as unknown as AppContextPageContentResolverContext;
 
     const module: AppStateHomepageJournalListingBlock = {
       kind: "homepageJournalListing",
@@ -106,11 +115,14 @@ describe("appContextResolveHomepageJournalListingBlock", () => {
     expect(mockedAppContextResolveJournalListingItems).toHaveBeenCalledTimes(1);
     expect(mockedAppContextResolveJournalListingItems).toHaveBeenCalledWith(
       context,
+      imageDelivery.homepageJournalFeature,
     );
   });
 
   it("returns empty entries when no journal items exist", () => {
-    const context = {} as AppContextPageContentResolverContext;
+    const context = {
+      imageDelivery,
+    } as unknown as AppContextPageContentResolverContext;
 
     const module: AppStateHomepageJournalListingBlock = {
       kind: "homepageJournalListing",
@@ -141,5 +153,10 @@ describe("appContextResolveHomepageJournalListingBlock", () => {
       flow: "content",
       entries: [],
     });
+
+    expect(mockedAppContextResolveJournalListingItems).toHaveBeenCalledWith(
+      context,
+      imageDelivery.homepageJournalFeature,
+    );
   });
 });

--- a/src/app-context/resolve/page-content/block/homepage-journal-listing/homepage-journal-listing.resolve.app-context.ts
+++ b/src/app-context/resolve/page-content/block/homepage-journal-listing/homepage-journal-listing.resolve.app-context.ts
@@ -12,9 +12,9 @@ export const appContextResolveHomepageJournalListingBlock = (
 ): AppContextHomepageJournalListingBlock => {
   return {
     ...module,
-    entries: appContextResolveJournalListingItems(context).slice(
-      0,
-      module.itemCount,
-    ),
+    entries: appContextResolveJournalListingItems(
+      context,
+      context.imageDelivery.homepageJournalFeature,
+    ).slice(0, module.itemCount),
   };
 };

--- a/src/app-context/resolve/page-content/block/image-strip/image-strip.resolve.app-context.test.ts
+++ b/src/app-context/resolve/page-content/block/image-strip/image-strip.resolve.app-context.test.ts
@@ -5,6 +5,13 @@ import type { AppStateImageStripBlock } from "@shared-types/page-content/block/i
 
 import { appContextResolveImageStripBlock } from "@app-context/resolve/page-content/block/image-strip/image-strip.resolve.app-context";
 
+const imageDelivery = {
+  homepageImageStrip: {
+    sizes: "(min-width: 1200px) 310px, (min-width: 768px) 33vw, 85vw",
+    widths: [320, 480, 640, 960],
+  },
+} as const;
+
 const createModule = (itemCount: number): AppStateImageStripBlock => ({
   kind: "imageStrip",
   source: "homepage-strip",
@@ -32,6 +39,7 @@ describe("appContextResolveImageStripBlock", () => {
     };
 
     const context = {
+      imageDelivery,
       homepageStripPhotoIds: ["coot", "heron"],
       resolvePhoto: jest.fn((photoId: string) => {
         if (photoId === "coot") return photoOne;
@@ -47,7 +55,16 @@ describe("appContextResolveImageStripBlock", () => {
 
     expect(result).toEqual({
       ...module,
-      photos: expect.arrayContaining([photoOne, photoTwo]),
+      photos: expect.arrayContaining([
+        {
+          metadata: photoOne,
+          delivery: imageDelivery.homepageImageStrip,
+        },
+        {
+          metadata: photoTwo,
+          delivery: imageDelivery.homepageImageStrip,
+        },
+      ]),
     });
 
     expect(result.photos).toHaveLength(2);
@@ -56,6 +73,7 @@ describe("appContextResolveImageStripBlock", () => {
 
   it("limits photos to the configured item count", () => {
     const context = {
+      imageDelivery,
       homepageStripPhotoIds: ["one", "two", "three"],
       resolvePhoto: jest.fn((photoId: string) => ({
         id: photoId,
@@ -70,7 +88,10 @@ describe("appContextResolveImageStripBlock", () => {
       ...module,
       photos: [
         {
-          id: expect.any(String),
+          metadata: {
+            id: expect.any(String),
+          },
+          delivery: imageDelivery.homepageImageStrip,
         },
       ],
     });
@@ -80,6 +101,7 @@ describe("appContextResolveImageStripBlock", () => {
 
   it("throws when a selected photo cannot be resolved", () => {
     const context = {
+      imageDelivery,
       homepageStripPhotoIds: ["missing-photo"],
       resolvePhoto: jest.fn(() => null),
     } as unknown as AppContextPageContentResolverContext;

--- a/src/app-context/resolve/page-content/block/image-strip/image-strip.resolve.app-context.ts
+++ b/src/app-context/resolve/page-content/block/image-strip/image-strip.resolve.app-context.ts
@@ -42,7 +42,10 @@ export const appContextResolveImageStripBlock = (
       );
     }
 
-    return photo;
+    return {
+      metadata: photo,
+      delivery: context.imageDelivery.homepageImageStrip,
+    };
   });
 
   return {

--- a/src/app-context/resolve/page-content/block/journal-listing/journal-listing.resolve.app-context.test.ts
+++ b/src/app-context/resolve/page-content/block/journal-listing/journal-listing.resolve.app-context.test.ts
@@ -22,6 +22,13 @@ jest.mock(
   }),
 );
 
+const imageDelivery = {
+  listingThumbnail: {
+    sizes: "(min-width: 768px) 220px, 33vw",
+    widths: [320, 480, 640, 960],
+  },
+} as const;
+
 const createModule = (): AppStateJournalListingBlock => ({
   kind: "journalListing",
   flow: "content",
@@ -51,7 +58,8 @@ describe("appContextResolveJournalListingBlock", () => {
       routingPagination: {
         currentPage: 2,
       },
-    } as AppContextPageContentResolverContext;
+      imageDelivery,
+    } as unknown as AppContextPageContentResolverContext;
 
     const journalItems = [
       { id: "one" },
@@ -92,6 +100,7 @@ describe("appContextResolveJournalListingBlock", () => {
 
     expect(mockedAppContextResolveJournalListingItems).toHaveBeenCalledWith(
       context,
+      imageDelivery.listingThumbnail,
     );
 
     expect(mockedAppContextResolvePagination).toHaveBeenCalledWith({
@@ -108,7 +117,8 @@ describe("appContextResolveJournalListingBlock", () => {
     const context = {
       currentPageSlug: "/journal",
       routingPagination: null,
-    } as AppContextPageContentResolverContext;
+      imageDelivery,
+    } as unknown as AppContextPageContentResolverContext;
 
     mockedAppContextResolveJournalListingItems.mockReturnValue([
       { id: "one" },
@@ -129,6 +139,11 @@ describe("appContextResolveJournalListingBlock", () => {
 
     expect(result.items).toEqual([{ id: "one" }, { id: "two" }]);
 
+    expect(mockedAppContextResolveJournalListingItems).toHaveBeenCalledWith(
+      context,
+      imageDelivery.listingThumbnail,
+    );
+
     expect(mockedAppContextResolvePagination).toHaveBeenCalledWith({
       pagination: module.pagination,
       currentPage: 1,
@@ -143,12 +158,18 @@ describe("appContextResolveJournalListingBlock", () => {
     const context = {
       currentPageSlug: null,
       routingPagination: null,
-    } as AppContextPageContentResolverContext;
+      imageDelivery,
+    } as unknown as AppContextPageContentResolverContext;
 
     mockedAppContextResolveJournalListingItems.mockReturnValue([]);
 
     expect(() => appContextResolveJournalListingBlock(module, context)).toThrow(
       "Missing current page slug for journal listing pagination.",
+    );
+
+    expect(mockedAppContextResolveJournalListingItems).toHaveBeenCalledWith(
+      context,
+      imageDelivery.listingThumbnail,
     );
   });
 });

--- a/src/app-context/resolve/page-content/block/journal-listing/journal-listing.resolve.app-context.ts
+++ b/src/app-context/resolve/page-content/block/journal-listing/journal-listing.resolve.app-context.ts
@@ -12,7 +12,10 @@ export const appContextResolveJournalListingBlock = (
   context: AppContextPageContentResolverContext,
 ): AppContextJournalListingBlock => {
   const currentPage = context.routingPagination?.currentPage ?? 1;
-  const journalItems = appContextResolveJournalListingItems(context);
+  const journalItems = appContextResolveJournalListingItems(
+    context,
+    context.imageDelivery.listingThumbnail,
+  );
 
   const baseHref = context.currentPageSlug;
 

--- a/src/app-context/resolve/page-content/shared/journal-listing-items.resolve.app-context.test.ts
+++ b/src/app-context/resolve/page-content/shared/journal-listing-items.resolve.app-context.test.ts
@@ -1,9 +1,46 @@
 // src/app-context/resolve/page-content/shared/journal-listing-items.resolve.app-context.test.ts
 
 import type { AppContextPageContentResolverContext } from "@app-context/resolve/types/context.page-content.resolve.app-context.types";
+import type { AppContextPhotoMetadata } from "@shared-types/media/photo/app-context.photo.types";
 import type { AppStatePageDefinition } from "@shared-types/page-definitions/app-state.page-definition.types";
 
 import { appContextResolveJournalListingItems } from "@app-context/resolve/page-content/shared/journal-listing-items.resolve.app-context";
+
+const imageDelivery = {
+  sizes: "(min-width: 768px) 220px, 33vw",
+  widths: [320, 480, 640, 960],
+} as const;
+
+const createPhoto = (
+  overrides: Partial<AppContextPhotoMetadata> = {},
+): AppContextPhotoMetadata =>
+  ({
+    id: "hero-photo",
+    sourceFileName: "hero-photo.jpg",
+    cloudflareImageId: "hero-photo",
+    cloudflareUploadedAt: null,
+    title: "Hero photo",
+    alt: "Hero photo alt",
+    commentary: "Hero photo commentary",
+    readableLocation: "Epping Forest",
+    capturedAt: null,
+    photographer: "Kevin Ellen",
+    copyright: "Kevin Ellen",
+    cameraMake: null,
+    cameraModel: null,
+    lensModel: null,
+    exposureTime: null,
+    aperture: null,
+    iso: null,
+    focalLength: null,
+    focalLength35mm: null,
+    width: 1200,
+    height: 800,
+    latitude: null,
+    longitude: null,
+    resolvedLocation: null,
+    ...overrides,
+  }) as AppContextPhotoMetadata;
 
 const createJournalPage = (
   overrides: Partial<AppStatePageDefinition> = {},
@@ -65,7 +102,9 @@ describe("appContextResolveJournalListingItems", () => {
     } as unknown as AppContextPageContentResolverContext;
 
     expect(
-      appContextResolveJournalListingItems(context).map((item) => item.id),
+      appContextResolveJournalListingItems(context, imageDelivery).map(
+        (item) => item.id,
+      ),
     ).toEqual(["newer-entry", "older-entry"]);
   });
 
@@ -89,7 +128,9 @@ describe("appContextResolveJournalListingItems", () => {
       resolvePhoto: jest.fn(() => null),
     } as unknown as AppContextPageContentResolverContext;
 
-    expect(appContextResolveJournalListingItems(context)).toEqual([
+    expect(
+      appContextResolveJournalListingItems(context, imageDelivery),
+    ).toEqual([
       {
         id: "valid",
         href: "/journal/valid",
@@ -119,15 +160,14 @@ describe("appContextResolveJournalListingItems", () => {
     } as unknown as AppContextPageContentResolverContext;
 
     expect(
-      appContextResolveJournalListingItems(context).map((item) => item.id),
+      appContextResolveJournalListingItems(context, imageDelivery).map(
+        (item) => item.id,
+      ),
     ).toEqual(["dated-entry", "a-entry", "z-entry"]);
   });
 
   it("resolves the first hero photo found inside article sections", () => {
-    const photo = {
-      id: "hero-photo",
-      title: "Hero photo",
-    };
+    const photo = createPhoto();
 
     const page = createJournalPage({
       content: {
@@ -171,14 +211,19 @@ describe("appContextResolveJournalListingItems", () => {
       ),
     } as unknown as AppContextPageContentResolverContext;
 
-    expect(appContextResolveJournalListingItems(context)[0]).toEqual({
+    expect(
+      appContextResolveJournalListingItems(context, imageDelivery)[0],
+    ).toEqual({
       id: "journal-one",
       href: "/journal/one",
       title: "Hero listing image",
       intro: "Intro",
       eyebrow: "Journal",
       publishedAt: null,
-      image: photo,
+      image: {
+        metadata: photo,
+        delivery: imageDelivery,
+      },
     });
 
     expect(context.resolvePhoto).toHaveBeenCalledWith("hero-photo");
@@ -192,7 +237,55 @@ describe("appContextResolveJournalListingItems", () => {
       resolvePhoto: jest.fn(() => null),
     } as unknown as AppContextPageContentResolverContext;
 
-    expect(appContextResolveJournalListingItems(context)[0].image).toBeNull();
+    expect(
+      appContextResolveJournalListingItems(context, imageDelivery)[0].image,
+    ).toBeNull();
+
     expect(context.resolvePhoto).not.toHaveBeenCalled();
+  });
+
+  it("throws when a referenced listing photo is missing from context", () => {
+    const page = createJournalPage({
+      content: {
+        head: {
+          title: "Missing image",
+          intro: "Intro",
+          eyebrow: "Journal",
+          showInBody: true,
+        },
+        content: [
+          {
+            kind: "articleSection",
+            heading: {
+              text: "Section",
+              level: 2,
+              visuallyHidden: false,
+            },
+            modules: [
+              {
+                kind: "hero",
+                photoId: "missing-photo",
+                immersive: false,
+                flow: "content",
+              },
+            ],
+          },
+        ],
+        footer: [],
+      },
+    });
+
+    const context = {
+      publicPages: [page],
+      resolvePhoto: jest.fn(() => null),
+    } as unknown as AppContextPageContentResolverContext;
+
+    expect(() =>
+      appContextResolveJournalListingItems(context, imageDelivery),
+    ).toThrow(
+      "No AppContext photo resolved for journal listing photoId: missing-photo",
+    );
+
+    expect(context.resolvePhoto).toHaveBeenCalledWith("missing-photo");
   });
 });

--- a/src/app-context/resolve/page-content/shared/journal-listing-items.resolve.app-context.ts
+++ b/src/app-context/resolve/page-content/shared/journal-listing-items.resolve.app-context.ts
@@ -1,8 +1,12 @@
 // src/app-context/resolve/page-content/shared/journal-listing-items.resolve.app-context.ts
 
 import type { AppContextPageContentResolverContext } from "@app-context/resolve/types/context.page-content.resolve.app-context.types";
+import type { AppContextImageDeliveryProfile } from "@shared-types/config/image-delivery/app-context.image-delivery.types";
 import type { AppStatePageDefinition } from "@shared-types/page-definitions/app-state.page-definition.types";
 import type { AppContextJournalListingItem } from "@shared-types/page-content/block/journal-listing/app-context.journal-listing.block.types";
+import type { AppContextResolvedPhoto } from "@shared-types/media/render-image/app-context.render-image.types";
+
+import { appContextResolvePhotoReference } from "@app-context/resolve/page-content/shared/photo-reference.resolve.app-context";
 
 const appContextResolveJournalPublishedAt = (
   page: AppStatePageDefinition,
@@ -17,6 +21,32 @@ const appContextResolveJournalListingPhotoId = (
     .filter((block) => block.kind === "articleSection")
     .flatMap((section) => section.modules)
     .find((block) => block.kind === "hero")?.photoId ?? null;
+
+const appContextResolveJournalListingImage = (
+  page: AppStatePageDefinition,
+  context: AppContextPageContentResolverContext,
+  imageDelivery: AppContextImageDeliveryProfile,
+): AppContextResolvedPhoto | null => {
+  const photoId = appContextResolveJournalListingPhotoId(page);
+
+  if (photoId === null) {
+    return null;
+  }
+
+  const photo = context.resolvePhoto(photoId);
+
+  if (photo === null) {
+    throw new Error(
+      `No AppContext photo resolved for journal listing photoId: ${photoId}`,
+    );
+  }
+
+  return appContextResolvePhotoReference({
+    reference: { id: photo.id },
+    photo,
+    delivery: imageDelivery,
+  });
+};
 
 const appContextIsPublicJournalPage = (
   page: AppStatePageDefinition,
@@ -35,22 +65,30 @@ const appContextCompareJournalPagesByNewestFirst = (
   return bPublishedAt.localeCompare(aPublishedAt) || a.id.localeCompare(b.id);
 };
 
+const appContextResolveJournalListingItem = (
+  page: AppStatePageDefinition & {
+    kind: "journal";
+    slug: `/${string}` | "/";
+  },
+  context: AppContextPageContentResolverContext,
+  imageDelivery: AppContextImageDeliveryProfile,
+): AppContextJournalListingItem => ({
+  id: page.id,
+  href: page.slug,
+  title: page.content.head.title,
+  intro: page.content.head.intro,
+  eyebrow: page.content.head.eyebrow,
+  publishedAt: appContextResolveJournalPublishedAt(page),
+  image: appContextResolveJournalListingImage(page, context, imageDelivery),
+});
+
 export const appContextResolveJournalListingItems = (
   context: AppContextPageContentResolverContext,
+  imageDelivery: AppContextImageDeliveryProfile,
 ): readonly AppContextJournalListingItem[] =>
   context.publicPages
     .filter(appContextIsPublicJournalPage)
     .sort(appContextCompareJournalPagesByNewestFirst)
-    .map((page) => {
-      const photoId = appContextResolveJournalListingPhotoId(page);
-
-      return {
-        id: page.id,
-        href: page.slug,
-        title: page.content.head.title,
-        intro: page.content.head.intro,
-        eyebrow: page.content.head.eyebrow,
-        publishedAt: appContextResolveJournalPublishedAt(page),
-        image: photoId === null ? null : context.resolvePhoto(photoId),
-      };
-    });
+    .map((page) =>
+      appContextResolveJournalListingItem(page, context, imageDelivery),
+    );

--- a/src/app-context/resolve/page-content/shared/photo-reference.resolve.app-context.test.ts
+++ b/src/app-context/resolve/page-content/shared/photo-reference.resolve.app-context.test.ts
@@ -1,0 +1,108 @@
+// src/app-context/resolve/page-content/shared/photo-reference.resolve.app-context.test.ts
+
+import type { AppContextPhotoMetadata } from "@shared-types/media/photo/app-context.photo.types";
+import type { AuthoredPhotoReference } from "@shared-types/media/render-image/authored.render-image.types";
+
+import { appContextResolvePhotoReference } from "@app-context/resolve/page-content/shared/photo-reference.resolve.app-context";
+
+const photo = {
+  id: "coot",
+  title: "Coot",
+} as AppContextPhotoMetadata;
+
+const delivery = {
+  sizes: "(min-width: 1200px) 640px, calc(100vw - 2rem)",
+  widths: [640, 960, 1280],
+} as const;
+
+const createReference = (
+  overrides: Partial<AuthoredPhotoReference> = {},
+): AuthoredPhotoReference => ({
+  id: "coot",
+  ...overrides,
+});
+
+describe("appContextResolvePhotoReference", () => {
+  it("returns photo metadata with the supplied delivery defaults", () => {
+    expect(
+      appContextResolvePhotoReference({
+        reference: createReference(),
+        photo,
+        delivery,
+      }),
+    ).toEqual({
+      metadata: photo,
+      delivery,
+    });
+  });
+
+  it("prefers authored sizes when provided", () => {
+    expect(
+      appContextResolvePhotoReference({
+        reference: createReference({
+          sizes: "(min-width: 900px) 400px, 90vw",
+        }),
+        photo,
+        delivery,
+      }).delivery,
+    ).toEqual({
+      sizes: "(min-width: 900px) 400px, 90vw",
+      widths: delivery.widths,
+    });
+  });
+
+  it("ignores blank authored sizes", () => {
+    expect(
+      appContextResolvePhotoReference({
+        reference: createReference({
+          sizes: "   ",
+        }),
+        photo,
+        delivery,
+      }).delivery.sizes,
+    ).toBe(delivery.sizes);
+  });
+
+  it("prefers authored widths when provided", () => {
+    expect(
+      appContextResolvePhotoReference({
+        reference: createReference({
+          widths: [320, 480],
+        }),
+        photo,
+        delivery,
+      }).delivery,
+    ).toEqual({
+      sizes: delivery.sizes,
+      widths: [320, 480],
+    });
+  });
+
+  it("ignores empty authored widths", () => {
+    expect(
+      appContextResolvePhotoReference({
+        reference: createReference({
+          widths: [],
+        }),
+        photo,
+        delivery,
+      }).delivery.widths,
+    ).toBe(delivery.widths);
+  });
+
+  it("allows authored sizes and widths to override together", () => {
+    expect(
+      appContextResolvePhotoReference({
+        reference: createReference({
+          sizes: "100vw",
+          widths: [960, 1280, 1600],
+        }),
+        photo,
+        delivery,
+      }).delivery,
+    ).toEqual({
+      sizes: "100vw",
+      widths: [960, 1280, 1600],
+    });
+  });
+});

--- a/src/app-context/resolve/page-content/shared/photo-reference.resolve.app-context.ts
+++ b/src/app-context/resolve/page-content/shared/photo-reference.resolve.app-context.ts
@@ -1,0 +1,29 @@
+// src/app-context/resolve/page-content/shared/photo-reference.resolve.app-context.ts
+
+import type { AppContextResolvedPhoto } from "@shared-types/media/render-image/app-context.render-image.types";
+import type { AppContextImageDeliveryProfile } from "@shared-types/config/image-delivery/app-context.image-delivery.types";
+import type { AppContextPhotoMetadata } from "@shared-types/media/photo/app-context.photo.types";
+import type { AuthoredPhotoReference } from "@shared-types/media/render-image/authored.render-image.types";
+
+export const appContextResolvePhotoReference = ({
+  reference,
+  photo,
+  delivery,
+}: Readonly<{
+  reference: AuthoredPhotoReference;
+  photo: AppContextPhotoMetadata;
+  delivery: AppContextImageDeliveryProfile;
+}>): AppContextResolvedPhoto => ({
+  metadata: photo,
+  delivery: {
+    sizes:
+      reference.sizes && reference.sizes.trim().length > 0
+        ? reference.sizes
+        : delivery.sizes,
+
+    widths:
+      reference.widths && reference.widths.length > 0
+        ? reference.widths
+        : delivery.widths,
+  },
+});

--- a/src/app-context/resolve/types/context.page-content.resolve.app-context.types.ts
+++ b/src/app-context/resolve/types/context.page-content.resolve.app-context.types.ts
@@ -7,6 +7,7 @@ import type { AppStateMetadataLabels } from "@shared-types/config/metadata-label
 import type { AppStatePageDefinition } from "@shared-types/page-definitions/app-state.page-definition.types";
 import type { PhotoId } from "@shared-types/media/photo/id.photo.types";
 import type { RoutingPagination } from "@request/types/request.types";
+import type { AppContextImageDeliveryConfig } from "@shared-types/config/image-delivery/app-context.image-delivery.types";
 
 export type AppContextPageContentResolverContext = Readonly<{
   photos: readonly AppContextPhotoMetadata[];
@@ -17,4 +18,5 @@ export type AppContextPageContentResolverContext = Readonly<{
   routingPagination: RoutingPagination | null;
   resolvePhoto: (photoId: string) => AppContextPhotoMetadata | null;
   currentPageSlug: string | null;
+  imageDelivery: AppContextImageDeliveryConfig;
 }>;

--- a/src/app-render-context/resolve/body-content/block/homepage-hero/homepage-hero.resolve.app-render-context.ts
+++ b/src/app-render-context/resolve/body-content/block/homepage-hero/homepage-hero.resolve.app-render-context.ts
@@ -13,11 +13,6 @@ export const appRenderContextResolveHomepageHeroBlock = (
   appContext: AppContext,
   block: AppContextHomepageHeroBlock,
 ): AppRenderContextHomepageHeroBlock => {
-  const photo = appRenderContextResolvePhoto(
-    block.photo,
-    appContext.metadataLabels,
-  );
-
   return {
     kind: "homepageHero",
     flow: block.flow,
@@ -26,7 +21,9 @@ export const appRenderContextResolveHomepageHeroBlock = (
     intro: block.intro.map((content) =>
       appRenderContextResolveInline(appContext, content),
     ),
-    photo: appRenderContextResolveRenderImage(photo),
+    photo: appRenderContextResolveRenderImage(
+      appRenderContextResolvePhoto(block.photo, appContext.metadataLabels),
+    ),
     primaryLink: block.primaryLink
       ? appRenderContextResolveLink(appContext, block.primaryLink)
       : null,

--- a/src/app-render-context/resolve/body-content/block/image-strip/image-strip.resolve.app-render-context.ts
+++ b/src/app-render-context/resolve/body-content/block/image-strip/image-strip.resolve.app-render-context.ts
@@ -8,26 +8,15 @@ import type {
 } from "@shared-types/page-content/block/image-strip/app-render-context.image-strip.block.types";
 
 import { appRenderContextResolvePhoto } from "@app-render-context/resolve/media/photo.resolve.app-render-context";
+import { appRenderContextResolveRenderImage } from "@app-render-context/resolve/media/render-image.resolve.app-render-context";
 
 const appRenderContextResolveImageStripPhoto = (
   appContext: AppContext,
   photo: AppContextImageStripBlock["photos"][number],
-): AppRenderContextImageStripPhoto => {
-  const resolvedPhoto = appRenderContextResolvePhoto(
-    photo,
-    appContext.metadataLabels,
+): AppRenderContextImageStripPhoto =>
+  appRenderContextResolveRenderImage(
+    appRenderContextResolvePhoto(photo, appContext.metadataLabels),
   );
-
-  return {
-    src: resolvedPhoto.src,
-    srcset: resolvedPhoto.srcset,
-    sizes: resolvedPhoto.sizes,
-    alt: resolvedPhoto.alt,
-    width: resolvedPhoto.width,
-    height: resolvedPhoto.height,
-    ratio: resolvedPhoto.ratio,
-  };
-};
 
 export const appRenderContextResolveImageStripBlock = (
   appContext: AppContext,

--- a/src/app-render-context/resolve/body-content/block/journal-listing/journal-listing.resolve.app-render-context.test.ts
+++ b/src/app-render-context/resolve/body-content/block/journal-listing/journal-listing.resolve.app-render-context.test.ts
@@ -80,15 +80,47 @@ describe("appRenderContextResolveJournalListingBlock", () => {
     mockedFormatDate.mockReturnValue("9 May 2026");
 
     const sourceImage = {
+      metadata: {
+        id: "coot-entry-image",
+      },
+      delivery: {
+        sizes: "(min-width: 768px) 220px, 33vw",
+        widths: [320, 480, 640, 960],
+      },
+    };
+
+    const resolvedPhoto = {
       id: "coot-entry-image",
+      title: "Coot entry image",
+      commentary: "A coot entry image.",
+      src: "/media/photo/coot-entry-image",
+      srcset: ["/media/photo/coot-entry-image/640/400 640w"],
+      sizes: "(min-width: 768px) 220px, 33vw",
+      alt: "Coot entry image",
+      width: 1600,
+      height: 1000,
+      ratio: {
+        width: 8,
+        height: 5,
+      },
+      attribution: null,
+      meta: [],
     };
 
     const resolvedImage = {
-      id: "coot-entry-image",
       src: "/media/photo/coot-entry-image",
+      srcset: ["/media/photo/coot-entry-image/640/400 640w"],
+      sizes: "(min-width: 768px) 220px, 33vw",
+      alt: "Coot entry image",
+      width: 1600,
+      height: 1000,
+      ratio: {
+        width: 8,
+        height: 5,
+      },
     };
 
-    mockedAppRenderContextResolvePhoto.mockReturnValue(resolvedImage as never);
+    mockedAppRenderContextResolvePhoto.mockReturnValue(resolvedPhoto as never);
 
     const block = createBlock({
       pagination: {

--- a/src/app-render-context/resolve/body-content/block/journal-listing/journal-listing.resolve.app-render-context.ts
+++ b/src/app-render-context/resolve/body-content/block/journal-listing/journal-listing.resolve.app-render-context.ts
@@ -1,12 +1,36 @@
 // src/app-render-context/resolve/body-content/block/journal-listing/journal-listing.resolve.app-render-context.ts
 
+// src/app-render-context/resolve/body-content/block/journal-listing/journal-listing.resolve.app-render-context.ts
+
 import type { AppContext } from "@app-context/class.app-context";
-import type { AppContextJournalListingBlock } from "@shared-types/page-content/block/journal-listing/app-context.journal-listing.block.types";
-import type { AppRenderContextJournalListingBlock } from "@shared-types/page-content/block/journal-listing/app-render-context.journal-listing.block.types";
+import type {
+  AppContextJournalListingBlock,
+  AppContextJournalListingItem,
+} from "@shared-types/page-content/block/journal-listing/app-context.journal-listing.block.types";
+import type {
+  AppRenderContextJournalListingBlock,
+  AppRenderContextJournalListingItem,
+} from "@shared-types/page-content/block/journal-listing/app-render-context.journal-listing.block.types";
 
 import { formatDate } from "@utils/date.format.util";
 import { appRenderContextResolvePagination } from "@app-render-context/resolve/body-content/shared/pagination.resolve.app-render-context";
 import { appRenderContextResolvePhoto } from "@app-render-context/resolve/media/photo.resolve.app-render-context";
+import { appRenderContextResolveRenderImage } from "@app-render-context/resolve/media/render-image.resolve.app-render-context";
+
+const appRenderContextResolveJournalListingItem = (
+  appContext: AppContext,
+  item: AppContextJournalListingItem,
+): AppRenderContextJournalListingItem => ({
+  ...item,
+  image:
+    item.image === null
+      ? null
+      : appRenderContextResolveRenderImage(
+          appRenderContextResolvePhoto(item.image, appContext.metadataLabels),
+        ),
+  publishedLabel:
+    item.publishedAt === null ? null : formatDate(item.publishedAt),
+});
 
 export const appRenderContextResolveJournalListingBlock = (
   appContext: AppContext,
@@ -14,13 +38,7 @@ export const appRenderContextResolveJournalListingBlock = (
 ): AppRenderContextJournalListingBlock => ({
   ...block,
   pagination: appRenderContextResolvePagination(block.pagination),
-  items: block.items.map((item) => ({
-    ...item,
-    image:
-      item.image === null
-        ? null
-        : appRenderContextResolvePhoto(item.image, appContext.metadataLabels),
-    publishedLabel:
-      item.publishedAt === null ? null : formatDate(item.publishedAt),
-  })),
+  items: block.items.map((item) =>
+    appRenderContextResolveJournalListingItem(appContext, item),
+  ),
 });

--- a/src/app-render-context/resolve/media/photo.resolve.app-render-context.test.ts
+++ b/src/app-render-context/resolve/media/photo.resolve.app-render-context.test.ts
@@ -2,6 +2,7 @@
 
 import type { AppStateMetadataLabels } from "@shared-types/config/metadata-labels/app-state.metadata-labels.types";
 import type { AppContextPhotoMetadata } from "@shared-types/media/photo/app-context.photo.types";
+import type { AppContextResolvedPhoto } from "@shared-types/media/render-image/app-context.render-image.types";
 
 import { appRenderContextResolvePhoto } from "@app-render-context/resolve/media/photo.resolve.app-render-context";
 import { formatDate } from "@utils/date.format.util";
@@ -14,6 +15,11 @@ jest.mock("@utils/date.format.util", () => ({
 jest.mock("@utils/normaliseDimensions.util", () => ({
   normaliseDimensionsToBase: jest.fn(),
 }));
+
+const delivery = {
+  sizes: "(min-width: 1200px) 640px, calc(100vw - 2rem)",
+  widths: [640, 960, 1280],
+} as const;
 
 const createMetadataLabels = (): AppStateMetadataLabels =>
   ({
@@ -48,6 +54,9 @@ const createPhoto = (
 ): AppContextPhotoMetadata =>
   ({
     id: "coot-in-soft-light",
+    sourceFileName: "coot-in-soft-light.jpg",
+    cloudflareImageId: "raw-cloudflare-id",
+    cloudflareUploadedAt: "2026-05-09T09:00:00.000Z",
     title: "Coot in soft light",
     alt: "A coot swimming through soft light.",
     commentary: "ARC commentary.",
@@ -56,31 +65,42 @@ const createPhoto = (
       utc: "2026-05-09T08:00:00.000Z",
       timezone: "Europe/London",
     },
-    width: 1600,
-    height: 1000,
-    src: null,
-    srcset: null,
-    sizes: null,
-    attribution: null,
-    ratio: null,
-    cloudflareImageId: "raw-cloudflare-id",
-    cloudflareUploadedAt: "2026-05-09T09:00:00.000Z",
     photographer: "Kevin Ellen",
     copyright: null,
-    latitude: 51.7,
-    longitude: 0.1,
-    resolvedLocation: {
-      country: "England",
-    },
     cameraMake: "Canon",
     cameraModel: "EOS R7",
     lensModel: "RF 100-500mm",
     exposureTime: 0.00125,
     aperture: 7.1,
-    focalLength: 500,
     iso: 12800,
+    focalLength: 500,
+    focalLength35mm: null,
+    width: 1600,
+    height: 1000,
+    latitude: 51.7,
+    longitude: 0.1,
+    resolvedLocation: {
+      name: null,
+      road: null,
+      village: null,
+      town: null,
+      city: null,
+      county: null,
+      state: null,
+      country: "England",
+      countryCode: "gb",
+      postcode: null,
+      displayName: "England",
+    },
     ...overrides,
-  }) as unknown as AppContextPhotoMetadata;
+  }) as AppContextPhotoMetadata;
+
+const createResolvedPhoto = (
+  overrides: Partial<AppContextPhotoMetadata> = {},
+): AppContextResolvedPhoto => ({
+  metadata: createPhoto(overrides),
+  delivery,
+});
 
 describe("appRenderContextResolvePhoto", () => {
   const mockedFormatDate = jest.mocked(formatDate);
@@ -100,7 +120,7 @@ describe("appRenderContextResolvePhoto", () => {
 
   it("resolves a render-safe photo shape", () => {
     const result = appRenderContextResolvePhoto(
-      createPhoto(),
+      createResolvedPhoto(),
       createMetadataLabels(),
     );
 
@@ -115,10 +135,9 @@ describe("appRenderContextResolvePhoto", () => {
       srcset: [
         "/media/photo/coot-in-soft-light/640/400 640w",
         "/media/photo/coot-in-soft-light/960/600 960w",
-        "/media/photo/coot-in-soft-light/1440/900 1440w",
-        "/media/photo/coot-in-soft-light/1920/1200 1920w",
+        "/media/photo/coot-in-soft-light/1280/800 1280w",
       ],
-      sizes: "(min-width: 1200px) 1200px, 100vw",
+      sizes: "(min-width: 1200px) 640px, calc(100vw - 2rem)",
       attribution: "Kevin Ellen",
       ratio: {
         width: 8,
@@ -185,7 +204,7 @@ describe("appRenderContextResolvePhoto", () => {
   it("uses copyright before photographer for attribution", () => {
     expect(
       appRenderContextResolvePhoto(
-        createPhoto({
+        createResolvedPhoto({
           copyright: "© Kevin Ellen",
           photographer: "Kevin Ellen",
         }),
@@ -197,7 +216,7 @@ describe("appRenderContextResolvePhoto", () => {
   it("returns null attribution when copyright and photographer are missing", () => {
     expect(
       appRenderContextResolvePhoto(
-        createPhoto({
+        createResolvedPhoto({
           copyright: null,
           photographer: null,
         }),
@@ -208,7 +227,7 @@ describe("appRenderContextResolvePhoto", () => {
 
   it("formats whole-second shutter speeds", () => {
     const result = appRenderContextResolvePhoto(
-      createPhoto({
+      createResolvedPhoto({
         exposureTime: 2,
       }),
       createMetadataLabels(),
@@ -227,8 +246,8 @@ describe("appRenderContextResolvePhoto", () => {
 
   it("omits empty metadata groups", () => {
     const result = appRenderContextResolvePhoto(
-      createPhoto({
-        readableLocation: undefined,
+      createResolvedPhoto({
+        readableLocation: "",
         capturedAt: null,
         exposureTime: null,
         aperture: null,
@@ -246,7 +265,7 @@ describe("appRenderContextResolvePhoto", () => {
     const metadataLabels = createMetadataLabels();
 
     const result = appRenderContextResolvePhoto(
-      createPhoto({
+      createResolvedPhoto({
         readableLocation: "Epping Forest",
         capturedAt: null,
         exposureTime: null,
@@ -280,7 +299,7 @@ describe("appRenderContextResolvePhoto", () => {
   it("normalises missing setting and capture metadata descriptions to null", () => {
     const metadataLabels = createMetadataLabels();
 
-    const result = appRenderContextResolvePhoto(createPhoto(), {
+    const result = appRenderContextResolvePhoto(createResolvedPhoto(), {
       ...metadataLabels,
       capturedAt: {
         label: "Captured",
@@ -352,7 +371,7 @@ describe("appRenderContextResolvePhoto", () => {
 
   it("formats captured date without timezone when captured timezone is missing", () => {
     appRenderContextResolvePhoto(
-      createPhoto({
+      createResolvedPhoto({
         capturedAt: {
           utc: "2026-05-09T08:00:00.000Z",
           timezone: null,

--- a/src/app-render-context/resolve/media/photo.resolve.app-render-context.ts
+++ b/src/app-render-context/resolve/media/photo.resolve.app-render-context.ts
@@ -7,11 +7,10 @@ import type {
   AppRenderContextPhotoMetaItem,
 } from "@shared-types/media/photo/app-render-context.photo.types";
 import type { AppStateMetadataLabels } from "@shared-types/config/metadata-labels/app-state.metadata-labels.types";
+import type { AppContextResolvedPhoto } from "@shared-types/media/render-image/app-context.render-image.types";
 
 import { normaliseDimensionsToBase } from "@utils/normaliseDimensions.util";
 import { formatDate } from "@utils/date.format.util";
-
-const PHOTO_SRCSET_WIDTHS = [640, 960, 1440, 1920] as const;
 
 const resolvePhotoHeight = (
   width: number,
@@ -126,10 +125,13 @@ const resolvePhotoMeta = (
 };
 
 export const appRenderContextResolvePhoto = (
-  photo: AppContextPhotoMetadata,
+  resolvedPhoto: AppContextResolvedPhoto,
   metadataLabels: AppStateMetadataLabels,
 ): AppRenderContextPhoto => {
-  const srcset = PHOTO_SRCSET_WIDTHS.map((width) => {
+  const photo = resolvedPhoto.metadata;
+  const delivery = resolvedPhoto.delivery;
+
+  const srcset = delivery.widths.map((width) => {
     const height = resolvePhotoHeight(width, photo.width, photo.height);
 
     return `${resolvePhotoUrl(photo.id, width, height)} ${width}w`;
@@ -143,7 +145,7 @@ export const appRenderContextResolvePhoto = (
     height: photo.height,
     src: resolvePhotoUrl(photo.id),
     srcset,
-    sizes: "(min-width: 1200px) 1200px, 100vw",
+    sizes: delivery.sizes,
     attribution: resolveAttribution(photo),
     ratio: normaliseDimensionsToBase(photo.width, photo.height),
     meta: resolvePhotoMeta(photo, metadataLabels),

--- a/src/app-render-context/resolve/media/render-image.resolve.app-render-context.ts
+++ b/src/app-render-context/resolve/media/render-image.resolve.app-render-context.ts
@@ -1,11 +1,7 @@
 // src/app-render-context/resolve/media/render-image.resolve.app-render-context.ts
 
-import type { AppRenderContextPhoto } from "@shared-types/media/photo/app-render-context.photo.types";
-
-export type AppRenderContextRenderImage = Pick<
-  AppRenderContextPhoto,
-  "src" | "srcset" | "sizes" | "alt" | "width" | "height" | "ratio"
->;
+import type { AppRenderContextPhoto } from "@shared-types/media/photo/app-render-context.render-photo.types";
+import type { AppRenderContextRenderImage } from "@shared-types/media/render-image/app-render-context.render-image.types";
 
 export const appRenderContextResolveRenderImage = (
   photo: AppRenderContextPhoto,

--- a/src/app-state/class.app-state.test.ts
+++ b/src/app-state/class.app-state.test.ts
@@ -7,6 +7,7 @@ import type { AppStateData } from "@app-state/types/app-state.types";
 const createAppStateData = (): AppStateData =>
   ({
     siteConfig: { siteName: "Test Site" },
+
     system: {
       goneRules: [
         {
@@ -14,6 +15,7 @@ const createAppStateData = (): AppStateData =>
           reason: "Removed",
         },
       ],
+
       redirectRules: [
         {
           fromPath: "/old",
@@ -22,7 +24,41 @@ const createAppStateData = (): AppStateData =>
         },
       ],
     },
+
     webManifest: { name: "Test Manifest" },
+
+    imageDelivery: {
+      homepageHero: {
+        sizes: "100vw",
+        widths: [960, 1280, 1600, 1920],
+      },
+
+      homepageJournalFeature: {
+        sizes: "(min-width: 1200px) 1200px, 100vw",
+        widths: [640, 960, 1440, 1920],
+      },
+
+      homepageImageStrip: {
+        sizes: "(min-width: 1200px) 33vw, 100vw",
+        widths: [320, 480, 640, 960],
+      },
+
+      listingThumbnail: {
+        sizes: "(min-width: 768px) 220px, 33vw",
+        widths: [320, 480, 640, 960],
+      },
+
+      fullBleed: {
+        sizes: "100vw",
+        widths: [960, 1280, 1600, 1920],
+      },
+
+      contentWidth: {
+        sizes: "(min-width: 1200px) 960px, calc(100vw - 2rem)",
+        widths: [640, 960, 1280, 1600],
+      },
+    },
+
     pages: {
       public: [
         {
@@ -31,6 +67,7 @@ const createAppStateData = (): AppStateData =>
           label: "Home",
           status: null,
         },
+
         {
           id: "draft-like-public-page",
           slug: null,
@@ -38,6 +75,7 @@ const createAppStateData = (): AppStateData =>
           status: null,
         },
       ],
+
       error: [
         {
           id: "not-found",
@@ -45,6 +83,7 @@ const createAppStateData = (): AppStateData =>
           label: "Not Found",
           status: 404,
         },
+
         {
           id: "invalid-error-page",
           slug: null,
@@ -53,6 +92,7 @@ const createAppStateData = (): AppStateData =>
         },
       ],
     },
+
     social: { links: [] },
     navigation: { items: [] },
     globalFooter: { sections: [] },
@@ -70,15 +110,22 @@ describe("AppState", () => {
     expect(appState.goneRules).toBe(data.system.goneRules);
     expect(appState.redirectRules).toBe(data.system.redirectRules);
     expect(appState.manifest).toBe(data.webManifest);
+
+    expect(appState.imageDelivery).toBe(data.imageDelivery);
+
     expect(appState.publicPages).toBe(data.pages.public);
     expect(appState.errorPages).toBe(data.pages.error);
+
     expect(appState.social).toBe(data.social);
     expect(appState.navigation).toBe(data.navigation);
     expect(appState.globalFooter).toBe(data.globalFooter);
     expect(appState.assets).toBe(data.assets);
+
     expect(appState.metadataLabels).toBe(data.metadataLabels);
     expect(appState.structuredData).toBe(data.structuredData);
+
     expect(appState.getPublicPages).toBe(data.pages.public);
+
     expect(appState.inspect).toBe(data);
   });
 
@@ -87,11 +134,13 @@ describe("AppState", () => {
     const appState = new AppState(data);
 
     expect(appState.getGoneRuleByPath("/gone")).toBe(data.system.goneRules[0]);
+
     expect(appState.getGoneRuleByPath("/missing")).toBeNull();
 
     expect(appState.getRedirectRuleByPath("/old")).toBe(
       data.system.redirectRules[0],
     );
+
     expect(appState.getRedirectRuleByPath("/missing")).toBeNull();
   });
 
@@ -102,11 +151,13 @@ describe("AppState", () => {
     expect(appState.getPublicPageById("home" as never)).toBe(
       data.pages.public[0],
     );
+
     expect(appState.getPublicPageBySlug("/")).toBe(data.pages.public[0]);
 
     expect(
       appState.getPublicPageById("draft-like-public-page" as never),
     ).toBeNull();
+
     expect(appState.getPublicPageBySlug("/missing")).toBeNull();
   });
 
@@ -117,9 +168,11 @@ describe("AppState", () => {
     expect(appState.getErrorPageById("not-found" as never)).toBe(
       data.pages.error[0],
     );
+
     expect(appState.getErrorPageByStatus(404)).toBe(data.pages.error[0]);
 
     expect(appState.getErrorPageById("invalid-error-page" as never)).toBeNull();
+
     expect(appState.getErrorPageByStatus(500)).toBeNull();
   });
 });

--- a/src/app-state/class.app-state.ts
+++ b/src/app-state/class.app-state.ts
@@ -17,6 +17,7 @@ import type { AppStateGlobalFooter } from "@shared-types/page-content/site/globa
 import type { AppStateAssets } from "@shared-types/assets/app-state.assets.types";
 import type { AppStateStructuredData } from "@shared-types/config/structured-data/app-state.structured-data.types";
 import type { AppStateMetadataLabels } from "@shared-types/config/metadata-labels/app-state.metadata-labels.types";
+import type { AppStateImageDeliveryConfig } from "@shared-types/config/image-delivery/app-state.image-delivery.types";
 
 const isPublicPageDefinition = (
   page: AppStatePageDefinition,
@@ -122,6 +123,10 @@ export class AppState {
 
   public get metadataLabels(): AppStateMetadataLabels {
     return this.#data.metadataLabels;
+  }
+
+  public get imageDelivery(): AppStateImageDeliveryConfig {
+    return this.#data.imageDelivery;
   }
 
   public get structuredData(): AppStateStructuredData {

--- a/src/app-state/config/image-delivery/authored.image-delivery.app-state.ts
+++ b/src/app-state/config/image-delivery/authored.image-delivery.app-state.ts
@@ -1,0 +1,45 @@
+// src/app-state/config/image-delivery/authored.image-delivery.app-state.ts
+
+import type { AuthoredImageDeliveryConfig } from "@shared-types/config/image-delivery/authored.image-delivery.types";
+
+export const authoredImageDeliveryConfig: AuthoredImageDeliveryConfig = {
+  fullBleed: {
+    sizes: "100vw",
+    widths: [960, 1280, 1600, 1920],
+  },
+
+  contentWidth: {
+    sizes: "(min-width: 64rem) 960px, calc(100vw - 2rem)",
+    widths: [640, 960, 1280, 1600],
+  },
+
+  homepageHero: {
+    sizes: "(min-width: 64rem) 800px, calc(100vw - 2rem)",
+    widths: [640, 800, 960, 1280],
+  },
+
+  homepageJournalFeature: {
+    sizes: "(min-width: 64rem) 650px, calc(100vw - 2rem)",
+    widths: [640, 960, 1280],
+  },
+
+  homepageImageStrip: {
+    sizes: "(min-width: 64rem) 325px, (min-width: 768px) 33vw, 85vw",
+    widths: [320, 480, 640],
+  },
+
+  listingThumbnail: {
+    sizes: "(min-width: 48rem) 575px, 100vw",
+    widths: [320, 480, 640],
+  },
+
+  articleHero: {
+    sizes: "(min-width: 64rem) 1250px, calc(100vw - 2rem)",
+    widths: [480, 640, 960, 1280, 1600],
+  },
+
+  articleInline: {
+    sizes: "(min-width: 64rem) 760px, calc(100vw - 2rem)",
+    widths: [640, 960, 1280, 1600],
+  },
+};

--- a/src/app-state/create.app-state.test.ts
+++ b/src/app-state/create.app-state.test.ts
@@ -110,6 +110,7 @@ describe("appStateCreate", () => {
       globalFooter,
       social: expect.anything(),
       metadataLabels: expect.anything(),
+      imageDelivery: expect.anything(),
       navigation: expect.anything(),
       structuredData,
       pages,

--- a/src/app-state/create.app-state.ts
+++ b/src/app-state/create.app-state.ts
@@ -12,6 +12,7 @@ import { appStateResolveMetadataLabels } from "@app-state/resolve/metadata-label
 import { appStateResolveNavigation } from "@app-state/resolve/navigation.resolve.app-state";
 import { appStateResolveStructuredData } from "@app-state/resolve/structured-data.resolve.app-state";
 import { appStateResolvePages } from "@app-state/resolve/pages.resolve.app-state";
+import { appStateResolveImageDelivery } from "@app-state/resolve/image-delivery.resolve.app-state";
 
 export const appStateCreate = async (env: Env): Promise<AppState> => {
   const siteConfig = appStateResolveSiteConfig(env);
@@ -25,6 +26,7 @@ export const appStateCreate = async (env: Env): Promise<AppState> => {
   const metadataLabels = appStateResolveMetadataLabels;
   const navigation = appStateResolveNavigation;
   const structuredData = appStateResolveStructuredData(siteConfig);
+  const imageDelivery = appStateResolveImageDelivery;
 
   const pages = await appStateResolvePages({
     journalKv: env.KV_JOURNALS,
@@ -39,6 +41,7 @@ export const appStateCreate = async (env: Env): Promise<AppState> => {
     globalFooter,
     social,
     metadataLabels,
+    imageDelivery,
     navigation,
     structuredData,
     pages,

--- a/src/app-state/resolve/assets.resolve.app-state.test.ts
+++ b/src/app-state/resolve/assets.resolve.app-state.test.ts
@@ -1,14 +1,78 @@
 // src/app-state/resolve/assets.resolve.app-state.test.ts
 
 import { appStateResolveAssets } from "@app-state/resolve/assets.resolve.app-state";
+
 import { AUTHORED_SCRIPT_ASSETS } from "@app-state/config/assets/authored.scripts.assets.app-state";
 import { AUTHORED_SVG_ASSETS } from "@app-state/config/assets/authored.svg.assets.app-state";
 
+jest.mock("@app-state/config/assets/authored.scripts.assets.app-state", () => ({
+  AUTHORED_SCRIPT_ASSETS: [
+    {
+      id: "inline-script",
+      kind: "inline",
+      content: "  console.log('hello');  ",
+      placement: "docClose",
+    },
+    {
+      id: "linked-script",
+      kind: "link",
+      src: "/assets/example.js",
+      placement: "docClose",
+    },
+  ],
+}));
+
+jest.mock("@app-state/config/assets/authored.svg.assets.app-state", () => ({
+  AUTHORED_SVG_ASSETS: [
+    {
+      id: "icon-test",
+      viewBox: "0 0 10 10",
+      content: "<path />",
+    },
+  ],
+}));
+
 describe("appStateResolveAssets", () => {
   it("resolves authored script and SVG assets", () => {
-    expect(appStateResolveAssets).toEqual({
-      scripts: AUTHORED_SCRIPT_ASSETS,
-      svg: AUTHORED_SVG_ASSETS,
+    expect(appStateResolveAssets.svg).toEqual(AUTHORED_SVG_ASSETS);
+
+    expect(appStateResolveAssets.scripts).toEqual(
+      AUTHORED_SCRIPT_ASSETS.map((script) =>
+        script.kind === "inline"
+          ? {
+              ...script,
+              content: script.content.trim(),
+            }
+          : script,
+      ),
+    );
+  });
+
+  it("trims inline script asset content", () => {
+    const inlineScripts = appStateResolveAssets.scripts.filter(
+      (script) => script.kind === "inline",
+    );
+
+    inlineScripts.forEach((script) => {
+      expect(script.content).toBe(script.content.trim());
     });
+  });
+
+  it("preserves non-inline script assets unchanged", () => {
+    const nonInlineScripts = AUTHORED_SCRIPT_ASSETS.filter(
+      (script) => script.kind !== "inline",
+    );
+
+    nonInlineScripts.forEach((script) => {
+      expect(appStateResolveAssets.scripts).toContainEqual(script);
+    });
+  });
+
+  it("deep freezes resolved assets", () => {
+    expect(Object.isFrozen(appStateResolveAssets)).toBe(true);
+
+    expect(Object.isFrozen(appStateResolveAssets.scripts)).toBe(true);
+
+    expect(Object.isFrozen(appStateResolveAssets.svg)).toBe(true);
   });
 });

--- a/src/app-state/resolve/image-delivery.resolve.app-state.ts
+++ b/src/app-state/resolve/image-delivery.resolve.app-state.ts
@@ -1,0 +1,8 @@
+// src/app-state/resolve/image-delivery.resolve.app-state.ts
+
+import type { AppStateImageDeliveryConfig } from "@shared-types/config/image-delivery/app-state.image-delivery.types";
+
+import { authoredImageDeliveryConfig } from "@app-state/config/image-delivery/authored.image-delivery.app-state";
+
+export const appStateResolveImageDelivery =
+  authoredImageDeliveryConfig satisfies AppStateImageDeliveryConfig;

--- a/src/app-state/types/app-state.types.ts
+++ b/src/app-state/types/app-state.types.ts
@@ -9,6 +9,7 @@ import type { AppStateSocial } from "@shared-types/config/social/app-state.socia
 import type { AppStateMetadataLabels } from "@shared-types/config/metadata-labels/app-state.metadata-labels.types";
 import type { AppStateNavigation } from "@shared-types/config/navigation/app-state.navigation.types";
 import type { AppStateStructuredData } from "@shared-types/config/structured-data/app-state.structured-data.types";
+import type { AppStateImageDeliveryConfig } from "@shared-types/config/image-delivery/app-state.image-delivery.types";
 
 import type { AppStatePages } from "@app-state/types/pages.app-state.types";
 
@@ -23,4 +24,5 @@ export type AppStateData = {
   navigation: AppStateNavigation;
   structuredData: AppStateStructuredData;
   pages: AppStatePages;
+  imageDelivery: AppStateImageDeliveryConfig;
 };

--- a/src/pages/public/static/authored.home.public.page.ts
+++ b/src/pages/public/static/authored.home.public.page.ts
@@ -102,7 +102,7 @@ export const authoredHomePublicPage: AuthoredPublicPageDefinition = deepFreeze({
             link: {
               kind: "internal",
               id: "notes",
-              text: "Read articles",
+              text: "Read notes",
             },
             icon: "icon-pencil",
           },
@@ -112,7 +112,7 @@ export const authoredHomePublicPage: AuthoredPublicPageDefinition = deepFreeze({
       {
         kind: "homepageNoteListing",
         heading: {
-          text: "Latest articles",
+          text: "Latest notes",
           level: 2,
         },
         itemCount: 3,
@@ -120,7 +120,7 @@ export const authoredHomePublicPage: AuthoredPublicPageDefinition = deepFreeze({
           {
             kind: "text",
             value:
-              "Articles are coming soon — thoughts on systems, photography, and digital craft.",
+              "Notes are coming soon — thoughts on systems, photography, and digital craft.",
           },
         ],
       },

--- a/src/styles/base/_base.scss
+++ b/src/styles/base/_base.scss
@@ -44,7 +44,6 @@ ul {
 ul li,
 ol li {
   display: grid;
-  grid-template-columns: 1.1rem 1fr;
   column-gap: tokens.$space-sm;
   align-items: start;
   margin-bottom: tokens.$space-sm;

--- a/src/styles/block/_journal-listing.scss
+++ b/src/styles/block/_journal-listing.scss
@@ -5,7 +5,6 @@
   flex-direction: column;
 
   &__list {
-    display: contents;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -64,7 +63,8 @@
     align-self: center;
     aspect-ratio: 4 / 3;
 
-    img {
+    img,
+    picture {
       display: block;
       width: 100%;
       height: 100%;


### PR DESCRIPTION
- separate photo metadata from render delivery intent
- introduce AppContextResolvedPhoto pipeline
- align responsive image sizes with actual layout widths
- reduce oversized homepage and listing image candidates
- standardise delivery policy through image-delivery config
- tighten ARC/render separation for image rendering
- add coverage for photo reference resolution and delivery logic